### PR TITLE
fix(images): render uploaded images by redirect; store S3 key in recipes

### DIFF
--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -1,0 +1,96 @@
+# Production readiness and hardening guide
+
+A pragmatic checklist to take this SPA + API stack from “works” to “production-ready.” Tackle top items first; iterate over time.
+
+## TL;DR checklist
+- [ ] Canonical redirect URI (apex only) and consistent login entry point
+- [ ] Tight CORS (origins, methods, headers) on API Gateway
+- [ ] Security headers at CloudFront (CSP, HSTS, X-Frame-Options, etc.)
+- [ ] GitHub Actions OIDC → AssumeRole (drop long-lived AWS keys)
+- [ ] Separate dev/stage/prod stacks and approvals
+- [ ] API logs, metrics, and CloudWatch alarms (5xx, latency)
+- [ ] DynamoDB: avoid full scans, add GSIs and pagination
+- [ ] IAM least privilege for Lambdas (narrow actions/resources)
+- [ ] DynamoDB PITR enabled; S3 versioning/lifecycle policies
+- [ ] WAF in front of API/CloudFront (rate limiting, IP rules)
+
+---
+
+## Authentication (Cognito)
+- Use a single canonical redirect domain (apex) to avoid host changes that break PKCE sessionStorage.
+- Keep callback/logout URLs in Terraform variables; restrict to your domains.
+- Token storage:
+  - Current: id/access tokens in localStorage (simple, common for SPAs).
+  - Stronger: exchange code via a tiny backend and set httpOnly, Secure, SameSite cookies.
+- Keep scopes minimal (openid email profile). Keep token lifetimes modest.
+
+## API Gateway + Lambda
+- CORS:
+  - Restrict allow_origins to your domains; allow only required methods/headers.
+  - Cache preflight responses (max_age) reasonably.
+- Routing/validation:
+  - Validate inputs (types, lengths). Return helpful 4xx on bad input.
+  - Enforce request size limits where appropriate (images go direct to S3 via presign—good).
+- Observability:
+  - Enable API Gateway access logs.
+  - Use structured JSON logs in Lambdas; add correlation IDs.
+  - Alarms: 5xx rate, p95 latency, throttles, DLQ visibility if used.
+- WAF: attach AWS WAF to API Gateway for basic protections and rate limiting.
+
+## Data layer (DynamoDB)
+- Avoid Scan for large tables; prefer Query via a key design that supports access patterns.
+- Add GSIs for non-key lookups (e.g., by tag/owner) if needed.
+- Implement pagination on list endpoints.
+- Turn on Point-in-Time Recovery (PITR) for tables.
+
+## Storage (S3) and CDN (CloudFront)
+- S3 site bucket:
+  - Versioning + lifecycle (already present in module; confirm settings).
+- CloudFront:
+  - Add security headers via response headers policy or function:
+    - Content-Security-Policy (script-src 'self' Cognito domain)
+    - Strict-Transport-Security
+    - X-Content-Type-Options: nosniff
+    - X-Frame-Options: DENY
+    - Referrer-Policy, Permissions-Policy
+  - Consider WAF on distribution.
+  - Keep www→apex redirect; avoid redirect during OAuth callback if you ever use www for redirects.
+
+## CI/CD (GitHub Actions)
+- Use OIDC to assume an AWS role (no static keys). See `docs/github-oidc.md`.
+- Split environments:
+  - Separate state/workspaces/stacks per env.
+  - Plans on PRs; applies on protected branches with approvals.
+- Build-time config:
+  - Current workflow exports Terraform outputs into Vite envs (good).
+  - Optional: runtime config.json if you need to change endpoints without rebuilds.
+
+## IAM and security
+- Narrow Lambda IAM policies to specific ARNs/actions.
+- S3 images bucket: ensure Put/Get/Delete are scoped to needed prefixes; continue using presigned URLs.
+- Rotate credentials; keep client IDs in repo variables (not secrets) as they’re not sensitive.
+
+## Testing
+- Unit tests for Lambdas (present) and UI (present)—extend with:
+  - E2E login + write-path tests.
+  - Contract tests for API responses.
+
+## Cost and performance
+- CloudFront cache policies for static assets; long max-age + immutable filenames.
+- Optimize images and prefer modern formats when feasible.
+- Use CloudWatch metrics and CUR to watch spend.
+
+## “Later” enhancements
+- Add refresh tokens via backend cookie flow if you need longer sessions.
+- Multi-tenant or multi-user authZ model if you expand beyond personal use.
+- Blue/green deploys for static site (S3 object version switch or dual buckets).
+
+---
+
+## Pointers to current repo
+- Terraform outputs: API/Cognito values flow into the Vite build via `.github/workflows/deploy.yml`.
+- www→apex redirect handled via CloudFront Function in `terraform/acm.tf`.
+- Public reads, auth-only writes enforced by API Gateway JWT authorizer and split routes.
+- Image uploads use S3 presigned URLs from the images Lambda.
+
+> Keep this doc as a living checklist and tick items off as you harden the stack.

--- a/terraform/lambda/images/app.py
+++ b/terraform/lambda/images/app.py
@@ -15,6 +15,18 @@ def response(status_code, body):
     }
 
 
+def redirect(location: str, status: int = 302):
+    return {
+        'statusCode': status,
+        'headers': {
+            'Location': location,
+            # Avoid default JSON header on redirects
+            'Cache-Control': 'private, max-age=300'
+        },
+        'body': ''
+    }
+
+
 def handler(event, context):
     # Support two operations:
     # POST /images -> returns { uploadUrl, key }
@@ -57,7 +69,8 @@ def handler(event, context):
                 Params={'Bucket': IMAGES_BUCKET, 'Key': key},
                 ExpiresIn=3600
             )
-            return response(200, {'url': url})
+            # Redirect to the signed URL so <img src> works directly
+            return redirect(url, 302)
 
         return response(400, {'message': 'Unsupported operation'})
     except ClientError as e:

--- a/terraform/lambda/tests/test_images.py
+++ b/terraform/lambda/tests/test_images.py
@@ -30,3 +30,26 @@ def test_get_presigned_url(monkeypatch):
     body = json.loads(res['body'])
     assert 'uploadUrl' in body
     assert 'key' in body
+
+
+@mock_aws()
+def test_get_image_redirect(monkeypatch):
+    s3 = boto3.client('s3', region_name='us-east-1')
+    bucket = 'mbm-site-images-test'
+    s3.create_bucket(Bucket=bucket)
+
+    monkeypatch.setenv('IMAGES_BUCKET', bucket)
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    module_path = os.path.join(repo_root, 'images', 'app.py')
+    images_app = load_module(module_path)
+
+    # Seed an object (key presence is not strictly required for presign, but good sanity)
+    s3.put_object(Bucket=bucket, Key='uploads/test.jpg', Body=b'data')
+
+    event = {'requestContext': {'http': {'method': 'GET'}}, 'rawPath': '/images/uploads/test.jpg'}
+    res = images_app.handler(event, None)
+    assert res['statusCode'] in (301, 302, 303, 307, 308)
+    # Must have Location header pointing at s3 presigned url
+    assert 'headers' in res and 'Location' in res['headers']
+    assert res['headers']['Location'].startswith('https://')


### PR DESCRIPTION
Lambda (images): return 302 redirect on GET /images/{key} to a fresh presigned S3 URL; POST /images still returns { uploadUrl, key }
Frontend: store durable S3 key after upload; render keys via ${API_BASE}/images/{key} so <img> follows redirect; normalize legacy presigned S3 URLs to keys; improve modal preview for key-based images
Tests: add unit test for 302 redirect on GET /images/{key}; all lambda and UI tests pass
Build: Vite production build compiles cleanly