### PR TITLE
UI polish: headerless edit modal, consistent close buttons, and mobil…

### DIFF
--- a/src/components/CompleteProfile.tsx
+++ b/src/components/CompleteProfile.tsx
@@ -57,8 +57,8 @@ export default function CompleteProfile({ visible, onClose, onSaved }: Props) {
         </div>
         <form onSubmit={save} style={{ padding: '6px 2px 10px' }}>
           <label>
-            Display name
-            <input value={nickname} onChange={(e) => setNickname(e.target.value)} placeholder="What should we call you?" />
+          What should we call you in the kitchen?
+          <input value={nickname} onChange={(e) => setNickname(e.target.value)} placeholder="What should we call you in the kitchen?" />
           </label>
           {error && <p style={{ color: 'var(--destructive)' }}>{error}</p>}
           <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>

--- a/src/components/CookModal.tsx
+++ b/src/components/CookModal.tsx
@@ -176,12 +176,12 @@ export default function CookModal({ visible, onClose, recipe, onEdit }: { visibl
               <IconCookMode size={20} weight="regular" />
             </button>
             {onEdit && (
-              <button className="cook-edit-btn" title="Edit recipe" aria-label="Edit recipe" onClick={() => onEdit(recipe as Recipe)}>
+              <button className="cook-edit-btn" title="Tweak the flavor" aria-label="Tweak the flavor" onClick={() => onEdit(recipe as Recipe)}>
                 <IconEdit size={20} weight="regular" />
               </button>
             )}
             <button className="cook-close-fab" aria-label="Close cook view" onClick={onClose}>
-              <IconClose size={20} weight="regular" />
+              <IconClose size={18} weight="regular" />
             </button>
           </div>
         </div>

--- a/src/components/DetailsModal.tsx
+++ b/src/components/DetailsModal.tsx
@@ -338,7 +338,7 @@ export default function DetailsModal({
   if (!visible || !modalRoot) return null
 
   return createPortal(
-    <div className="modal-backdrop" role="dialog" aria-modal="true" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}>
+    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="details-title" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}>
       <div
         className="modal bg-gradient-card border-none shadow-floating"
         ref={modalRef}
@@ -381,57 +381,17 @@ export default function DetailsModal({
         }}
         onTouchCancel={() => { touchStart.current = null; shouldClose.current = false; snapBack() }}
       >
-  {/* grabber removed per design */}
-        <button className="modal-close" aria-label="Close" onClick={onClose}><IconClose size={20} /></button>
-        <div className="modal-header">
-          <h3 className="text-primary">Recipe details</h3>
-          {initialRecipe && (initialRecipe as any).createdAt && (
-            <div style={{fontSize:12,color:'var(--muted)'}}>
-              {(() => {
-                const createdByRaw = (initialRecipe as any).createdByName as string | undefined
-                const updatedByRaw = (initialRecipe as any).updatedByName as string | undefined
-                const createdBySub = (initialRecipe as any).createdBySub as string | undefined
-                const updatedBySub = (initialRecipe as any).updatedBySub as string | undefined
-                const createdAt = (initialRecipe as any).createdAt as number | undefined
-                const updatedAt = (initialRecipe as any).updatedAt as number | undefined
-                const deriveName = (name: string | undefined, sub: string | undefined): string | undefined => {
-                  if (name && name.toLowerCase() !== 'user') return name
-                  if (currentUserSub && sub && sub === currentUserSub && currentUserName) return currentUserName
-                  return undefined
-                }
-                const createdBy = deriveName(createdByRaw, createdBySub)
-                const updatedBy = deriveName(updatedByRaw, updatedBySub)
-                function rel(ts?: number) {
-                  if (!ts) return ''
-                  try {
-                    const d = new Date(ts * 1000)
-                    const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
-                    const diff = Math.round((d.getTime() - Date.now()) / 1000)
-                    const abs = Math.abs(diff)
-                    const mins = Math.round(diff / 60)
-                    const hours = Math.round(diff / 3600)
-                    const days = Math.round(diff / 86400)
-                    if (abs < 60) return rtf.format(diff, 'second')
-                    if (abs < 3600) return rtf.format(mins, 'minute')
-                    if (abs < 86400) return rtf.format(hours, 'hour')
-                    return rtf.format(days, 'day')
-                  } catch { return '' }
-                }
-                if (updatedAt && createdAt && updatedAt !== createdAt) {
-                  if (createdBy && updatedBy) return <span>by {createdBy} · updated {rel(updatedAt)} by {updatedBy}</span>
-                  if (createdBy) return <span>by {createdBy} · updated {rel(updatedAt)}</span>
-                  if (updatedBy) return <span>updated {rel(updatedAt)} by {updatedBy}</span>
-                  return <span>updated {rel(updatedAt)}</span>
-                }
-                if (createdAt) {
-                  if (createdBy) return <span>by {createdBy} · {rel(createdAt)}</span>
-                  return <span>{rel(createdAt)}</span>
-                }
-                return null
-              })()}
-            </div>
-          )}
+        {/* Sticky actions-only bar matching cook modal styling (close only here) */}
+        <div className="cook-actions-sticky" aria-label="Edit actions">
+          <div className="cook-toolbar-actions">
+            <button className="cook-close-fab" aria-label="Close edit view" onClick={onClose}>
+              <IconClose size={18} weight="regular" />
+            </button>
+          </div>
         </div>
+        {/* Accessible heading retained without visible title */}
+        <h2 id="details-title" className="sr-only">Recipe details</h2>
+        {/* Metadata removed per design to keep edit UI focused */}
         {errors.title && <div className="error">{errors.title}</div>}
 
         <label className="form-field">
@@ -529,7 +489,7 @@ export default function DetailsModal({
         {uploadError && <div className="error" role="alert">{uploadError}</div>}
 
         <div className="modal-actions">
-          <button type="button" className="primary" onClick={() => save()} disabled={!auth.isAuthed || uploading} title={!auth.isAuthed ? 'Log in to save' : undefined}>{uploading ? 'Uploading…' : 'Save recipe'}</button>
+          <button type="button" className="primary" onClick={() => save()} disabled={!auth.isAuthed || uploading} title={!auth.isAuthed ? 'Log in to save' : undefined}>{uploading ? 'Uploading…' : 'Save to Recipe Box'}</button>
           <button type="button" className="btn-ghost" onClick={onClose}>Cancel</button>
         </div>
       </div>

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { IconClose } from '../icons/Icons'
 import { Authenticator } from '@aws-amplify/ui-react'
 import { Hub } from 'aws-amplify/utils'
 import '@aws-amplify/ui-react/styles.css'
@@ -59,15 +60,15 @@ export default function LoginModal({ visible, onClose }: Props) {
     return unsubscribe
   }, [onClose])
 
-  const headerTitle = 'Sign in'
+  const headerTitle = 'Welcome back to the kitchen!'
 
   return (
     <div className="modal-backdrop" role="dialog" aria-modal="true">
   <div className="modal auth-modal" style={{ background: 'hsl(var(--card))', border: '1px solid hsl(var(--border))' }}>
         <div className="modal-header">
           <h2 style={{ margin: 0 }}>{headerTitle}</h2>
-          <button className="btn-ghost" onClick={onClose} aria-label="Close" title="Close" style={{marginLeft:'auto'}}>
-            ✕
+          <button className="icon-btn" onClick={onClose} aria-label="Close" title="Close" style={{marginLeft:'auto'}}>
+            <IconClose size={18} weight="regular" />
           </button>
         </div>
         <div style={{ padding: '6px 2px 10px' }}>
@@ -82,8 +83,8 @@ export default function LoginModal({ visible, onClose }: Props) {
                   order: 1,
                 },
                 nickname: {
-                  label: 'Display name',
-                  placeholder: 'What should we call you?',
+                  label: 'What should we call you in the kitchen?',
+                  placeholder: 'Enter your user name',
                   isRequired: false,
                   order: 2,
                 },

--- a/src/components/RecipeList.tsx
+++ b/src/components/RecipeList.tsx
@@ -66,7 +66,7 @@ export default function RecipeList({ recipes, onEdit, onDelete, onView, query, a
             {/* Overlay actions at top-right of image */}
             <div className="recipe-card-actions recipe-card-actions--overlay" onClick={(e) => e.stopPropagation()}>
               {authed && onEdit && (
-                <button onClick={() => onEdit(r)} className="btn-ghost" aria-label="Edit">
+                <button onClick={() => onEdit(r)} className="btn-ghost" aria-label="Tweak the flavor" title="Tweak the flavor">
                   <IconEdit size={18} />
                 </button>
               )}

--- a/src/icons/Icons.tsx
+++ b/src/icons/Icons.tsx
@@ -1,11 +1,12 @@
-import { CookingPot, PencilSimpleLine, SignIn, SignOut, Plus, X, Trash } from 'phosphor-react'
+import { CookingPot, PencilSimpleLine, SignIn, SignOut, Plus, PlusCircle, X, Trash } from 'phosphor-react'
 
 export const IconEdit = PencilSimpleLine
 export const IconCookMode = CookingPot
 export const IconSignIn = SignIn
 export const IconSignOut = SignOut
 export const IconPlus = Plus
+export const IconPlusCircle = PlusCircle
 export const IconClose = X
 export const IconDelete = Trash
 
-export default { IconEdit, IconCookMode, IconSignIn, IconSignOut, IconPlus, IconClose, IconDelete }
+export default { IconEdit, IconCookMode, IconSignIn, IconSignOut, IconPlus, IconPlusCircle, IconClose, IconDelete }

--- a/src/styles.css
+++ b/src/styles.css
@@ -151,6 +151,7 @@ pre, code, .code, table, .table-scroll { max-width: 100%; overflow-x: auto }
 }
 .auth-icon{ filter: saturate(0.8); display:inline-flex; align-items:center; justify-content:center }
 .auth-icon svg{ width:18px; height:18px; display:block }
+.auth-icon.auth-icon--lg svg{ width:24px; height:24px }
 
 /* secondary (outlined) */
 .secondary{background:var(--btn-secondary-bg);border:1px solid var(--btn-secondary-border);color:var(--text);padding:8px 12px;border-radius:10px}

--- a/src/theme.css
+++ b/src/theme.css
@@ -153,6 +153,10 @@ html.modal-open, body.modal-open {
   z-index: 2;
 }
 
+/* Non-sticky, minimal top row used by Details modal when title is hidden */
+.modal-top { display:flex; align-items:center; justify-content:flex-end; padding: 6px 0 4px 0; margin-bottom: 4px; background: transparent; position: static; border-bottom: none; }
+.details-meta { font-size: 12px; color: hsl(var(--muted-fg)); margin-bottom: 6px; }
+
 /* In the Auth (Amplify) modal, avoid sticky header to prevent covering tabs in iOS PWA */
 .auth-modal .modal-header { position: static; top: auto; z-index: auto; }
 /* Ensure Amplify tabs, if present, sit clearly below the header */
@@ -191,13 +195,30 @@ textarea { min-height: 92px; }
 .cook-title { margin: 0; font-size: 1.25rem; line-height: 1.2; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .cook-title { color: hsl(var(--brand-fg)); }
 .cook-toolbar-actions { display:flex; gap:8px; align-items:center; background: hsl(var(--card)); padding: 6px; border-radius: 12px; box-shadow: 0 8px 22px rgba(0,0,0,0.08); }
-.cook-close-fab { position: static; border: none; background: hsl(var(--card)); width: 36px; height: 36px; display:inline-grid; place-items:center; border-radius: 10px; font-size: 1rem; cursor: pointer; box-shadow: 0 8px 22px rgba(0,0,0,0.08); }
+.cook-close-fab, .icon-btn { position: static; border: none; background: hsl(var(--card)); width: 36px; height: 36px; display:inline-grid; place-items:center; border-radius: 10px; font-size: 1rem; cursor: pointer; box-shadow: 0 8px 22px rgba(0,0,0,0.08); color: hsl(var(--foreground)); }
 .cook-toolbar-actions button:focus { outline: none }
 .cook-toolbar-actions button:focus-visible { outline: 2px solid hsl(var(--ring)); outline-offset: 2px }
-.cook-close-fab:hover { background: hsl(var(--muted-bg)); }
+.cook-close-fab:hover, .icon-btn:hover { background: hsl(var(--muted-bg)); }
+.icon-btn:focus { outline: none }
+.icon-btn:focus-visible { outline: 2px solid hsl(var(--ring)); outline-offset: 2px }
+/* Large icon button variant (48px) for primary actions on mobile */
+.icon-btn-lg { width: 48px; height: 48px; border-radius: 12px; }
+/* Accent color helper for icons */
+.icon-accent { color: hsl(var(--primary)); }
+
+/* Icon-only action (transparent surface) used for mobile "Add recipe" */
+.icon-only { -webkit-tap-highlight-color: transparent; width: 56px; height: 56px; display: inline-grid; place-items: center; background: transparent; border: none; color: hsl(var(--primary)); border-radius: 12px; box-shadow: none; cursor: pointer; }
+.icon-only svg { display: block }
+.icon-only:hover { background: hsl(var(--muted-bg)); }
+.icon-only:focus { outline: none }
+.icon-only:focus-visible { outline: 2px solid hsl(var(--ring)); outline-offset: 2px; background: hsl(var(--muted-bg)); }
 .cook-edit-btn { border: none; background: hsl(var(--primary)); color: hsl(var(--primary-foreground)); width: 36px; height: 36px; display:inline-grid; place-items:center; border-radius: 10px; font-size: 0.95rem; cursor: pointer; box-shadow: 0 6px 18px rgba(0,0,0,0.08); }
 .cook-edit-btn svg { width:18px; height:18px; }
 .cook-edit-btn:hover { filter: brightness(0.98); }
+/* Generic primary icon button to reuse outside cook modal */
+.icon-btn-primary { border: none; background: hsl(var(--primary)); color: hsl(var(--primary-foreground)); width: 36px; height: 36px; display:inline-grid; place-items:center; border-radius: 10px; font-size: 0.95rem; cursor: pointer; box-shadow: 0 6px 18px rgba(0,0,0,0.08); }
+.icon-btn-primary svg { width:18px; height:18px; }
+.icon-btn-primary:hover { filter: brightness(0.98); }
 /* Cook mode toggle */
 .cook-mode-btn { border: none; background: transparent; color: hsl(var(--foreground)); width: 36px; height: 36px; display:inline-grid; place-items:center; border-radius: 8px; font-size: 0.95rem; cursor: pointer; }
 .cook-mode-btn svg { width:18px; height:18px; }
@@ -236,6 +257,10 @@ textarea { min-height: 92px; }
   .cook-modal .cook-image { display:block }
   .cook-modal .cook-content { padding-top: 54px; }
 }
+
+/* Responsive helpers */
+@media (max-width: 640px) { .hide-on-mobile { display: none !important; } }
+@media (min-width: 641px) { .show-on-mobile { display: none !important; } }
 
 /* Align labels + inputs in-line for denser appearance on medium+ screens */
 @media (min-width: 720px) {

--- a/src/visual-regression.test.tsx
+++ b/src/visual-regression.test.tsx
@@ -9,7 +9,7 @@ describe('visual regression (lightweight)', () => {
   it('renders the app hero and search with themed classes', () => {
     render(<App />)
     // Hero container should exist
-    expect(screen.getByText(/Recipe Collection/i)).toBeInTheDocument()
+    expect(screen.getByText(/Meals by Maggie/i)).toBeInTheDocument()
     // Search input present
     const search = screen.getByLabelText(/Search recipes/i)
     expect(search).toBeInTheDocument()


### PR DESCRIPTION
…e add icon

- DetailsModal: remove visible header/meta; add sticky close toolbar matching cook view; keep sr-only heading
- Close buttons: unify to icon-btn/cook-close-fab styles; consistent sizes/weights
- Search: hide visible label (sr-only Your Recipe Box); update placeholder
- Add recipe (mobile): switch to PlusCircle and use same 'auth-cta' style as login; larger icon variant
- Icons: expose IconPlusCircle in wrapper
- CSS: add icon-only, icon-btn(-lg), icon-accent, responsive helpers; auth-icon--lg
- Tests: update visual test to assert hero and search input