### PR TITLE
Fix heredoc delimiter collision in workflow output capture

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,9 +59,9 @@ jobs:
           else
             echo "apply_status=failure" >> $GITHUB_OUTPUT
           fi
-          echo "tf_summary<<EOF" >> $GITHUB_OUTPUT
+          echo "tf_summary<<TF_OUTPUT_DELIM" >> $GITHUB_OUTPUT
           tail -n 200 tfapply.log >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "TF_OUTPUT_DELIM" >> $GITHUB_OUTPUT
 
       - name: Get outputs
         id: tfout

--- a/.github/workflows/terraform-ai-account.yml
+++ b/.github/workflows/terraform-ai-account.yml
@@ -141,9 +141,9 @@ jobs:
             echo "apply_status=failure" >> $GITHUB_OUTPUT
             exit $exit_code
           fi
-          echo "tf_summary<<EOF" >> $GITHUB_OUTPUT
+          echo "tf_summary<<TF_OUTPUT_DELIM" >> $GITHUB_OUTPUT
           tail -n 200 tfapply.log >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "TF_OUTPUT_DELIM" >> $GITHUB_OUTPUT
 
       - name: Summary
         if: always()


### PR DESCRIPTION
Terraform logs contain the literal string "EOF" which broke GitHub Actions multiline output capture. Use a unique delimiter to avoid the conflict.