### PR TITLE
Fix route_key fallback to handle POST /ai/extract-recipe

### DIFF
--- a/terraform/app_account/lambda/recipes/app.py
+++ b/terraform/app_account/lambda/recipes/app.py
@@ -214,6 +214,8 @@ def handler(event, context):
                 route_key = f'{method} /recipes/{{id}}'
             elif path == '/ratings' and method in ('GET', 'POST'):
                 route_key = f'{method} /ratings'
+            elif path == '/ai/extract-recipe' and method == 'POST':
+                route_key = 'POST /ai/extract-recipe'
 
     # If route_key provided but unexpected (e.g., path has trailing slash), re-derive a normalized key
     expected = {
@@ -461,4 +463,4 @@ def handler(event, context):
             print(f"extract-recipe error: {e}")
             return response(500, {'error': str(e)})
 
-    return response(400, {'message': 'Unsupported operation', 'route_key': route_key, 'method': method, 'path': raw_path})
+    return response(400, {'message': 'Unsupported operation'})


### PR DESCRIPTION
API Gateway doesn't set routeKey in the event payload for this route, so the path-based fallback needs to map it explicitly like the others. Also removes debug fields from catch-all error response.